### PR TITLE
Add absolute dates

### DIFF
--- a/pages/guide.md
+++ b/pages/guide.md
@@ -15,7 +15,7 @@ This page provides implementation guidance for [Binding Operational Directive 18
 
 * Within **30 days** of BOD issuance *(November 15th, 2017)*, submit an "Agency Plan of Action" to <FNR.BOD@hq.dhs.gov> and begin implementing the plan.
 * At **60 days** *(December 15th, 2017)* after BOD issuance (**and at every 30 days until full implementation**), provide a status report of plan implementation to <FNR.BOD@hq.dhs.gov>.
-* Within **90 days** *(January 14, 2018)* of BOD issuance:
+* Within **90 days** *(January 15, 2018)* of BOD issuance:
   * Configure all internet-facing mail servers to offer STARTTLS.
   * Configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of "p=none" and at least one address defined as a recipient of aggregate and/or failure reports.
 * By **120 days** *(February 13, 2018)* after BOD issuance:
@@ -25,8 +25,6 @@ This page provides implementation guidance for [Binding Operational Directive 18
   * Disable 3DES and RC4 ciphers on web and mail servers.
 * Within **15 days of the establishment of a centralized NCCIC reporting location**, add DHS as a recipient of DMARC aggregate reports.
 * Within **one year** *(October 16, 2018)* of BOD issuance, set a DMARC policy of "reject" for all second-level domains and mail-sending hosts.
-
-These dates provide a time buffer for Federal holidays.
 
 ### Frequently Asked Questions
 Answers to other common compliance questions appear below.

--- a/pages/guide.md
+++ b/pages/guide.md
@@ -13,18 +13,18 @@ This page provides implementation guidance for [Binding Operational Directive 18
 
 ### Checklist
 
-* Within **30 days** of BOD issuance (November 15th, 2017), submit an "Agency Plan of Action" to <FNR.BOD@hq.dhs.gov> and begin implementing the plan.
-* At **60 days** (December 15th, 2017) after BOD issuance (**and at every 30 days until full implementation**), provide a status report of plan implementation to <FNR.BOD@hq.dhs.gov>.
-* Within **90 days** (January 22, 2018) of BOD issuance:
+* Within **30 days** of BOD issuance *(November 15th, 2017)*, submit an "Agency Plan of Action" to <FNR.BOD@hq.dhs.gov> and begin implementing the plan.
+* At **60 days** *(December 15th, 2017)* after BOD issuance (**and at every 30 days until full implementation**), provide a status report of plan implementation to <FNR.BOD@hq.dhs.gov>.
+* Within **90 days** *(January 22, 2018)* of BOD issuance:
   * Configure all internet-facing mail servers to offer STARTTLS.
   * Configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of "p=none" and at least one address defined as a recipient of aggregate and/or failure reports.
-* By **120 days** (February 20, 2018) after BOD issuance:
+* By **120 days** *(February 20, 2018)* after BOD issuance:
   * Ensure all publicly accessible Federal websites and web services provide service through a secure connection (HTTPS-only, with HSTS).
   * Identify agency second-level domains that can be HSTS preloaded, and provide a list to DHS at <FNR.BOD@hq.dhs.gov>.
   * Disable SSLv2 and SSLv3 on web and mail servers.
   * Disable 3DES and RC4 ciphers on web and mail servers.
 * Within **15 days of the establishment of a centralized NCCIC reporting location**, add DHS as a recipient of DMARC aggregate reports.
-* Within **one year** (October 26, 2018) of BOD issuance, set a DMARC policy of "reject" for all second-level domains and mail-sending hosts.
+* Within **one year** *(October 26, 2018)* of BOD issuance, set a DMARC policy of "reject" for all second-level domains and mail-sending hosts.
 
 These dates provide a time buffer for Federal holidays.
 

--- a/pages/guide.md
+++ b/pages/guide.md
@@ -15,16 +15,16 @@ This page provides implementation guidance for [Binding Operational Directive 18
 
 * Within **30 days** of BOD issuance *(November 15th, 2017)*, submit an "Agency Plan of Action" to <FNR.BOD@hq.dhs.gov> and begin implementing the plan.
 * At **60 days** *(December 15th, 2017)* after BOD issuance (**and at every 30 days until full implementation**), provide a status report of plan implementation to <FNR.BOD@hq.dhs.gov>.
-* Within **90 days** *(January 22, 2018)* of BOD issuance:
+* Within **90 days** *(January 14, 2018)* of BOD issuance:
   * Configure all internet-facing mail servers to offer STARTTLS.
   * Configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of "p=none" and at least one address defined as a recipient of aggregate and/or failure reports.
-* By **120 days** *(February 20, 2018)* after BOD issuance:
+* By **120 days** *(February 13, 2018)* after BOD issuance:
   * Ensure all publicly accessible Federal websites and web services provide service through a secure connection (HTTPS-only, with HSTS).
   * Identify agency second-level domains that can be HSTS preloaded, and provide a list to DHS at <FNR.BOD@hq.dhs.gov>.
   * Disable SSLv2 and SSLv3 on web and mail servers.
   * Disable 3DES and RC4 ciphers on web and mail servers.
 * Within **15 days of the establishment of a centralized NCCIC reporting location**, add DHS as a recipient of DMARC aggregate reports.
-* Within **one year** *(October 26, 2018)* of BOD issuance, set a DMARC policy of "reject" for all second-level domains and mail-sending hosts.
+* Within **one year** *(October 16, 2018)* of BOD issuance, set a DMARC policy of "reject" for all second-level domains and mail-sending hosts.
 
 These dates provide a time buffer for Federal holidays.
 

--- a/pages/guide.md
+++ b/pages/guide.md
@@ -13,17 +13,20 @@ This page provides implementation guidance for [Binding Operational Directive 18
 
 ### Checklist
 
-* Within **30 days** of BOD issuance, submit an "Agency Plan of Action" to <FNR.BOD@hq.dhs.gov> and begin implementing the plan.
-* At **60 days** after BOD issuance (**and at every 30 days until full implementation**), provide a status report of plan implementation to <FNR.BOD@hq.dhs.gov>.
-* Within **90 days** of BOD issuance, configure all internet-facing mail servers to offer STARTTLS.
-* By **120 days** after BOD issuance:
+* Within **30 days** of BOD issuance (November 15th, 2017), submit an "Agency Plan of Action" to <FNR.BOD@hq.dhs.gov> and begin implementing the plan.
+* At **60 days** (December 15th, 2017) after BOD issuance (**and at every 30 days until full implementation**), provide a status report of plan implementation to <FNR.BOD@hq.dhs.gov>.
+* Within **90 days** (January 22, 2018) of BOD issuance:
+  * Configure all internet-facing mail servers to offer STARTTLS.
   * Configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of "p=none" and at least one address defined as a recipient of aggregate and/or failure reports.
+* By **120 days** (February 20, 2018) after BOD issuance:
   * Ensure all publicly accessible Federal websites and web services provide service through a secure connection (HTTPS-only, with HSTS).
   * Identify agency second-level domains that can be HSTS preloaded, and provide a list to DHS at <FNR.BOD@hq.dhs.gov>.
   * Disable SSLv2 and SSLv3 on web and mail servers.
   * Disable 3DES and RC4 ciphers on web and mail servers.
 * Within **15 days of the establishment of a centralized NCCIC reporting location**, add DHS as a recipient of DMARC aggregate reports.
-* Within **one year** of BOD issuance, set a DMARC policy of "reject" for all second-level domains and mail-sending hosts.
+* Within **one year** (October 26, 2018) of BOD issuance, set a DMARC policy of "reject" for all second-level domains and mail-sending hosts.
+
+These dates provide a time buffer for Federal holidays.
 
 ### Frequently Asked Questions
 Answers to other common compliance questions appear below.

--- a/pages/index.md
+++ b/pages/index.md
@@ -100,7 +100,7 @@ All agencies are **required** to:
 1.  [Within 30 calendar days](/guide/#checklist) after issuance of this directive, develop
     and provide to DHS an "Agency Plan of Action for BOD 18-01" to:
 
-    a.  Enhance email security by:
+    a.  **Enhance email security by**:
 
       >i. [Within 90 days](/guide/#checklist) after issuance of this directive,
             configuring:
@@ -125,7 +125,7 @@ All agencies are **required** to:
             DMARC policy of "reject" for all second-level domains and
             mail-sending hosts.
 
-    b.  Enhance web security by:
+    b.  **Enhance web security by**:
 
       >i.  [Within 120 days](/guide/#checklist) after issuance of this directive, ensuring:
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -97,12 +97,12 @@ security.
 
 All agencies are **required** to:
 
-1.  Within 30 calendar days after issuance of this directive, develop
+1.  [Within 30 calendar days](/guide/#checklist) after issuance of this directive, develop
     and provide to DHS an "Agency Plan of Action for BOD 18-01" to:
 
     a.  Enhance email security by:
 
-      >i. Within 90 days after issuance of this directive,
+      >i. [Within 90 days](/guide/#checklist) after issuance of this directive,
             configuring:
 
       >-  All internet-facing mail servers to offer STARTTLS, and
@@ -112,7 +112,7 @@ All agencies are **required** to:
                 at least one address defined as a recipient of aggregate
                 and/or failure reports.
 
-      >ii. Within 120 days after issuance of this directive, ensuring:
+      >ii. [Within 120 days](/guide/#checklist) after issuance of this directive, ensuring:
 
       >-  Secure Sockets Layer (SSL)v2 and SSLv3 are disabled on
                 mail servers, and
@@ -121,13 +121,13 @@ All agencies are **required** to:
 
       >iii. Within 15 days of the establishment of centralized National Cybersecurity & Communications Integration Center (NCCIC) reporting location, adding the NCCIC as a recipient of DMARC aggregate reports.
 
-      >iv. Within one year after issuance of this directive, setting a
+      >iv. [Within one year](/guide/#checklist) after issuance of this directive, setting a
             DMARC policy of "reject" for all second-level domains and
             mail-sending hosts.
 
     b.  Enhance web security by:
 
-      >i.  Within 120 days after issuance of this directive, ensuring:
+      >i.  [Within 120 days](/guide/#checklist) after issuance of this directive, ensuring:
 
       > +  All publicly accessible Federal websites and web
                 services provide service through a secure connection
@@ -145,9 +145,9 @@ All agencies are **required** to:
     days of this directive per required action 1, begin implementing
     that plan.
 
-3.  At 60 calendar days after issuance of this directive, provide a
+3.  At [60 calendar days](/guide/#checklist) after issuance of this directive, provide a
     report to DHS on the status of that implementation. Continue to
-    report every 30 calendar days thereafter until implementation of the
+    report [every 30 calendar days](/guide/#checklist) thereafter until implementation of the
     agency’s BOD 18-01 plan is complete.
 
 ### III. DHS Actions


### PR DESCRIPTION
This change adds actual, absolute dates to the /guide page (fixes #5) whereby agencies must comply with BOD 18-01. It also:
* adds links from the index page (the text of the BOD) to /guide
* fixes an error that incorrectly put initial DMARC compliance in the 120 day bucket instead of the 90 day bucket where it belongs
* minor style changes to the index page
