### PR TITLE
Fix DMARC compliance timeline error on /guide

### DIFF
--- a/pages/guide.md
+++ b/pages/guide.md
@@ -15,9 +15,10 @@ This page provides implementation guidance for [Binding Operational Directive 18
 
 * Within **30 days** of BOD issuance, submit an "Agency Plan of Action" to <FNR.BOD@hq.dhs.gov> and begin implementing the plan.
 * At **60 days** after BOD issuance (**and at every 30 days until full implementation**), provide a status report of plan implementation to <FNR.BOD@hq.dhs.gov>.
-* Within **90 days** of BOD issuance, configure all internet-facing mail servers to offer STARTTLS.
-* By **120 days** after BOD issuance:
+* Within **90 days** of BOD issuance:
+  * Configure all internet-facing mail servers to offer STARTTLS.
   * Configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of "p=none" and at least one address defined as a recipient of aggregate and/or failure reports.
+* By **120 days** after BOD issuance:
   * Ensure all publicly accessible Federal websites and web services provide service through a secure connection (HTTPS-only, with HSTS).
   * Identify agency second-level domains that can be HSTS preloaded, and provide a list to DHS at <FNR.BOD@hq.dhs.gov>.
   * Disable SSLv2 and SSLv3 on web and mail servers.


### PR DESCRIPTION
This change fixes an error that incorrectly put initial DMARC compliance in the 120 day bucket instead of the 90 day bucket where it belongs, as the Directive makes clear.

This fix was proposed in #8 but is being made separately because it's not an addition, it's an error we're 
fixing, and the deadline dates are under review.