### PR TITLE
Add trailing slash to fix redirects

### DIFF
--- a/pages/18-01.md
+++ b/pages/18-01.md
@@ -3,10 +3,10 @@ layout: base
 title: Binding Operational Directive 18-01
 permalink: /bod/18-01/
 redirect_from:
-  - /intro
-  - /guide
-  - /https
-  - /resources
+  - /intro/
+  - /guide/
+  - /https/
+  - /resources/
 
 subnav:
   - text: Introduction to Email Authentication


### PR DESCRIPTION
The last PR added redirects (via Jekyll's [redirect-from](https://github.com/jekyll/jekyll-redirect-from)) from now-consolidated pages. This worked locally but not when deployed. This change adds trailing slashes to the config, which appears to work on a test build. 

🤞🤞🤞