### PR TITLE
Add trailing slash to https.cio.gov link

### DIFF
--- a/pages/18-01.md
+++ b/pages/18-01.md
@@ -349,7 +349,7 @@ Some examples of top-level domains (TLDs; sometimes called "[public suffixes](ht
 
 
 #### How does the web security requirement in BOD 18-01 differ from M-15-13?
-BOD 18-01 incorporates parallel language to M-15-13 with regard to HTTPS deployment. The [Compliance Guide at https.cio.gov](https://https.cio.gov/guide) **should be consulted** in implementing HTTPS and HSTS.
+BOD 18-01 incorporates parallel language to M-15-13 with regard to HTTPS deployment. The [Compliance Guide at https.cio.gov](https://https.cio.gov/guide/) **should be consulted** in implementing HTTPS and HSTS.
 
 BOD 18-01 also mandates two additional steps:
 1. *The disabling of old SSL versions (SSLv2 and SSLv3) and legacy cipher suites (3DES and RC4)*. In 2014, [NIST marked SSLv2/v3 and RC4 as "not approved"](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf#page=17), and in 2017, [NIST urged all users of 3DES to migrate](https://csrc.nist.gov/News/2017/Update-to-Current-Use-and-Deprecation-of-TDEA) as soon as possible.


### PR DESCRIPTION
Unfortunately, we still have a weird configuration where leaving off the trailing slash causes a redirect to the underlying `app.cloud.gov` URL, which is un-ideal. Only one link had this issue that I could find on the BOD 18-01 page.