### PR TITLE
Add link to parsedmarc in resources

### DIFF
--- a/pages/18-01.md
+++ b/pages/18-01.md
@@ -488,7 +488,7 @@ BOD 18-01 requires federal agencies to set a DMARC policy of `p=reject`, which c
 ### Tools
 * ["DMARC Guide"](https://dmarcguide.globalcyberalliance.org/) from Global Cyber Alliance, is a one-off [SPF](https://dmarcguide.globalcyberalliance.org/#/spf), [DKIM](https://dmarcguide.globalcyberalliance.org/#/dkim), and [DMARC](https://dmarcguide.globalcyberalliance.org/#/dmarc) policy analyzer and record creator.
 * [`trustymail`](https://github.com/dhs-ncats/trustymail) and [`pshtt`](https://github.com/dhs-ncats/pshtt) are DHS open-source Python scanners to check for SPF/DMARC/STARTTLS usage and HTTPS best practices, respectively.
-* [`parsedmarc`](https://domainaware.github.io/parsedmarc/) is a Python package and CLI tool that can parse aggregate and forensic DMARC reports, and optionally send them to an Elasticsearch instance, where they can be visuallized using premade Kibana dashboards.
+* [`parsedmarc`](https://domainaware.github.io/parsedmarc/) is a Python package and CLI tool that can parse aggregate and forensic DMARC reports, and optionally send them to an Elasticsearch instance where they can be visualized using premade Kibana dashboards.
 
 ### Tutorials
 * ["Add a DMARC Record"](https://support.google.com/a/answer/2466563?hl=en) is a Google help page that offers a stepped approach to enabling DMARC thoughtfully.

--- a/pages/18-01.md
+++ b/pages/18-01.md
@@ -488,6 +488,7 @@ BOD 18-01 requires federal agencies to set a DMARC policy of `p=reject`, which c
 ### Tools
 * ["DMARC Guide"](https://dmarcguide.globalcyberalliance.org/) from Global Cyber Alliance, is a one-off [SPF](https://dmarcguide.globalcyberalliance.org/#/spf), [DKIM](https://dmarcguide.globalcyberalliance.org/#/dkim), and [DMARC](https://dmarcguide.globalcyberalliance.org/#/dmarc) policy analyzer and record creator.
 * [`trustymail`](https://github.com/dhs-ncats/trustymail) and [`pshtt`](https://github.com/dhs-ncats/pshtt) are DHS open-source Python scanners to check for SPF/DMARC/STARTTLS usage and HTTPS best practices, respectively.
+* [`parsedmarc`](https://domainaware.github.io/parsedmarc/) is a Python package and CLI tool that can parse aggregate and forensic DMARC reports, and optionally send them to an Elasticsearch instance, where they can be visuallized using premade Kibana dashboards.
 
 ### Tutorials
 * ["Add a DMARC Record"](https://support.google.com/a/answer/2466563?hl=en) is a Google help page that offers a stepped approach to enabling DMARC thoughtfully.


### PR DESCRIPTION
Hi everyone,

I've been working on a Python package called `parsedmarc` with the following features:

- Parses draft and 1.0 standard aggregate reports
- Parses forensic reports
- Can parse reports from an inbox over IMAP
- Transparently handles gzip or zip compressed reports
- Consistent data structures
- Simple JSON and/or CSV output
- Optionally email the results
- Optionally send the results to Elasticsearch, for use with premade Kibana dashboards

I'd like to add a link `parsedmarc`'s documentation to BOD 2018-01's DMARC tools list.

https://domainaware.github.io/parsedmarc/